### PR TITLE
Fix name of third party log4j-scan library in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ As many in industry, we did not feel the need to "re-invent the wheel". This
 recommended scanning solution is derived from the great work of others (with slight modifications). We've included two additional
 projects to avoid using third-parties.
 
-[log4-scanner](https://github.com/fullhunt/log4j-scan) - Log4j vulnerability scanning framework. **Thank you to the fullhunt.io team.**
+[log4j-scan](https://github.com/fullhunt/log4j-scan) - Log4j vulnerability scanning framework. **Thank you to the fullhunt.io team.**
 
 [dns](https://gist.github.com/pklaus/b5a7876d4d2cf7271873) - Simple DNS server (UDP and TCP) in Python. **Thank you pklaus & andreif.**
 


### PR DESCRIPTION
The README linked to `log4j-scan` by the name of `log4-scanner` - this fixes that.