### PR TITLE
Added Custom IP Callback Option

### DIFF
--- a/log4-scanner/README.md
+++ b/log4-scanner/README.md
@@ -63,6 +63,8 @@ optional arguments:
                         Test using payloads for CVE-2021-45046 (detection payloads).
   --dns-callback-provider DNS_CALLBACK_PROVIDER
                         DNS Callback provider (Options: dnslog.cn, interact.sh) - [Default: interact.sh].
+  --custom-ip-callback-host CUSTOM_IP_CALLBACK_HOST
+                        Option to specify IP address and Port instead of DNS Callback
   --custom-dns-callback-host CUSTOM_DNS_CALLBACK_HOST
                         Custom DNS Callback Host.
   --disable-http-redirects


### PR DESCRIPTION
# Custom IP Callback #

I've added the following command:
`--custom-ip-callback-host`

## Purpose ##
Different orgs may be against making DNS changes or using a 3rd Party provider to scan for exploits. This will allow you to run your own instance of netcat or equivalent and receive responses from vulnerable hosts to your IP.


## Code Changes ##
Naming conventions and styling have been matched to original author. 
Some variables have been changed from dns specific to generic as they may now be holding an IP address.
README.md has been updated.

## Differences in Functionality ##
Adding this functionality requires removing the hostname from the payload when using this parameter. Tools such as netcat will be able to provide you with the IP addresses of the inbound connections.

When using this parameter the CVE-2021-45046 test will not function as this requires DNS. The script will output an error informing the user of the problem so its made clear. Additionally, the jndi:dns payload will not be successful, but with rmi and ldap functioning properly any vulnerable system will likely report correctly.
